### PR TITLE
Fix monitoring metrics for individual collectors

### DIFF
--- a/collectors/cache.go
+++ b/collectors/cache.go
@@ -88,21 +88,33 @@ type collectorCacheEntry struct {
 
 // NewCollectorCache returns a new CollectorCache with the given TTL
 func NewCollectorCache(ttl time.Duration) *CollectorCache {
-	return &CollectorCache{
+	c := &CollectorCache{
 		cache: make(map[string]*collectorCacheEntry),
 		ttl:   ttl,
 	}
+
+	go c.cleanup()
+	return c
 }
 
 // Get returns a MonitoringCollector if the key is found and not expired
+// If key is found it resets the TTL for the collector
 func (c *CollectorCache) Get(key string) (*MonitoringCollector, bool) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 
 	entry, ok := c.cache[key]
-	if !ok || time.Now().After(entry.expiry) {
+
+	if !ok {
 		return nil, false
 	}
+
+	if time.Now().After(entry.expiry) {
+		delete(c.cache, key)
+		return nil, false
+	}
+
+	entry.expiry = time.Now().Add(c.ttl)
 	return entry.collector, true
 }
 
@@ -115,4 +127,24 @@ func (c *CollectorCache) Store(key string, collector *MonitoringCollector) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	c.cache[key] = entry
+}
+
+func (c *CollectorCache) cleanup() {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+	for range ticker.C {
+		c.removeExpired()
+	}
+}
+
+func (c *CollectorCache) removeExpired() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	now := time.Now()
+	for key, entry := range c.cache {
+		if now.After(entry.expiry) {
+			delete(c.cache, key)
+		}
+	}
 }

--- a/collectors/cache_test.go
+++ b/collectors/cache_test.go
@@ -74,3 +74,56 @@ func TestDescriptorCache(t *testing.T) {
 		t.Error("cache entries should have expired")
 	}
 }
+
+func TestCollectorCache(t *testing.T) {
+	createCollector := func(id string) *MonitoringCollector {
+		return &MonitoringCollector{
+			projectID: id,
+		}
+	}
+
+	t.Run("basic cache Op", func(t *testing.T) {
+		ttl := 1 * time.Second
+		cache := NewCollectorCache(ttl)
+		collector := createCollector("test-project")
+		key := "test-key"
+
+		cache.Store(key, collector)
+
+		if _, found := cache.Get("test-key"); !found {
+			t.Error("Collector should be available in cache before TTL")
+		}
+
+		time.Sleep(2 * ttl)
+		if _, found := cache.Get("test-key"); found {
+			t.Error("Collector should have expired")
+		}
+	})
+
+	t.Run("multiple collectors", func(t *testing.T) {
+		ttl := 1 * time.Second
+		cache := NewCollectorCache(ttl)
+
+		collectors := map[string]*MonitoringCollector{
+			"test-key-1": createCollector("test-project-1"),
+			"test-key-2": createCollector("test-project-2"),
+			"test-key-3": createCollector("test-project-3"),
+		}
+
+		for k, v := range collectors {
+			cache.Store(k, v)
+		}
+
+		for k, original := range collectors {
+			cached, found := cache.Get(k)
+			if !found {
+				t.Errorf("Collector %s not found in cache", k)
+				continue
+			}
+
+			if cached.projectID != original.projectID {
+				t.Errorf("Wrong collector for key %s. Got projectId %s, want %s", k, cached.projectID, original.projectID)
+			}
+		}
+	})
+}

--- a/stackdriver_exporter.go
+++ b/stackdriver_exporter.go
@@ -242,7 +242,7 @@ func (h *handler) getCollector(project string, filters map[string]bool) (*collec
 	}
 
 	collector, err := collectors.NewMonitoringCollector(project, h.m, collectors.MonitoringCollectorOptions{
-		MetricTypePrefixes:        h.filterMetricTypePrefixes(filters),
+		MetricTypePrefixes:        filterdPrefixes,
 		ExtraFilters:              h.metricsExtraFilters,
 		RequestInterval:           *monitoringMetricsInterval,
 		RequestOffset:             *monitoringMetricsOffset,

--- a/stackdriver_exporter.go
+++ b/stackdriver_exporter.go
@@ -257,12 +257,14 @@ func (h *handler) filterMetricTypePrefixes(filters map[string]bool) []string {
 	if len(filters) > 0 {
 		filteredPrefixes = nil
 		for _, prefix := range h.metricsPrefixes {
-			if filters[prefix] {
-				filteredPrefixes = append(filteredPrefixes, prefix)
+			for filter, _ := range filters {
+				if strings.HasPrefix(filter, prefix) {
+					filteredPrefixes = append(filteredPrefixes, filter)
+				}
 			}
 		}
 	}
-	return filteredPrefixes
+	return parseMetricTypePrefixes(filteredPrefixes)
 }
 
 func main() {

--- a/stackdriver_exporter.go
+++ b/stackdriver_exporter.go
@@ -205,16 +205,15 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func newHandler(projectIDs []string, metricPrefixes []string, metricExtraFilters []collectors.MetricFilter, m *monitoring.Service, logger *slog.Logger, additionalGatherer prometheus.Gatherer) *handler {
-	ttl := 2 * time.Hour
+	var ttl time.Duration
 	// Add collector caching TTL as max of deltas aggregation or descriptor caching
 	if *monitoringMetricsAggregateDeltas || *monitoringDescriptorCacheTTL > 0 {
-		featureTTL := *monitoringMetricsDeltasTTL
-		if *monitoringDescriptorCacheTTL > featureTTL {
-			featureTTL = *monitoringDescriptorCacheTTL
+		ttl = *monitoringMetricsDeltasTTL
+		if *monitoringDescriptorCacheTTL > ttl {
+			ttl = *monitoringDescriptorCacheTTL
 		}
-		if featureTTL > ttl {
-			ttl = featureTTL
-		}
+	} else {
+		ttl = 2 * time.Hour
 	}
 
 	logger.Info("Creating collector cache", "ttl", ttl)

--- a/stackdriver_exporter_test.go
+++ b/stackdriver_exporter_test.go
@@ -35,3 +35,29 @@ func TestParseMetricTypePrefixes(t *testing.T) {
 		t.Errorf("Metric type prefix sanitization did not produce expected output. Expected:\n%s\nGot:\n%s", expectedOutputPrefixes, outputPrefixes)
 	}
 }
+
+func TestFilterMetricTypePrefixes(t *testing.T) {
+	metricPrefixes := []string{
+		"redis.googleapis.com/stats/",
+	}
+
+	h := &handler{
+		metricsPrefixes: metricPrefixes,
+	}
+
+	inputFilters := map[string]bool{
+		"redis.googleapis.com/stats/memory/usage":       true,
+		"redis.googleapis.com/stats/memory/usage_ratio": true,
+		"redis.googleapis.com":                          true,
+	}
+
+	expectedOutputPrefixes := []string{
+		"redis.googleapis.com/stats/memory/usage",
+	}
+
+	outputPrefixes := h.filterMetricTypePrefixes(inputFilters)
+
+	if !reflect.DeepEqual(outputPrefixes, expectedOutputPrefixes) {
+		t.Errorf("filterMetricTypePrefixes did not produce expected output. Expected:\n%s\nGot:\n%s", expectedOutputPrefixes, outputPrefixes)
+	}
+}


### PR DESCRIPTION
## Fix monitoring metrics

### Problem
We are relying on collector based scrape to fetch metric. Collector's monitoring metrics e.g. `api_calls_total`, `scrapes_total` etc isn't reported properly.

Currently, each time a metrics endpoint is hit (with  `collect` parameter e.g., `/metrics?collect=pubsub.googleapis.com/topic`), a new collector is created. This causes the internal collector metrics (`stackdriver_monitoring_api_calls_total`, `stackdriver_monitoring_scrapes_total` etc.) to reset on each scrape since they're recreated in each api call.

## Solution
This PR:
- Add collector caching in the handler using a map
- Key the cache using project ID + filters combination
- Reuse collectors across scrapes to maintain metric state

## Testing
- [x] Tested build locally, with one of our GCP project for different collector(s)
- [x] Deployed in one of our cluster and tested with multiple collector (~ 110 different metrics-type-prefixes)
- [x] Verified metrics accumulate properly across scrapes for each collector
- [x] Memory usage remains stable over time and is similar to previous version